### PR TITLE
Fix accordion initialization

### DIFF
--- a/js/interface.js
+++ b/js/interface.js
@@ -7,6 +7,9 @@ export async function initInterface() {
 
   const container = document.querySelector('#interface');
   container.innerHTML = buildFilters(interests, departments, courses);
+  if (window.Rivet && typeof window.Rivet.init === 'function') {
+    window.Rivet.init(container);
+  }
 }
 
 function buildFilters(interests, departments, courses) {


### PR DESCRIPTION
## Summary
- initialize Rivet after filters are rendered so accordion panels start closed

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_685efb32d2588326945cd6390c81edc9