### PR TITLE
Improve course display layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,7 +11,15 @@
     <script type="module" src="js/app.js"></script>
 </head>
 <body>
-    <main id="interface" class="rvt-container-lg rvt-p-tb-md"></main>
-    <section id="course-list" class="rvt-container-lg rvt-p-tb-md"></section>
+    <div class="rvt-container-lg rvt-p-tb-md">
+        <div class="rvt-row">
+            <div class="rvt-cols-12 rvt-cols-4-md rvt-p-right-md">
+                <main id="interface"></main>
+            </div>
+            <div class="rvt-cols-12 rvt-cols-8-md">
+                <section id="course-list"></section>
+            </div>
+        </div>
+    </div>
 </body>
 </html>

--- a/js/app.js
+++ b/js/app.js
@@ -18,9 +18,27 @@ async function loadCourses() {
 }
 
 function renderCourses(courses) {
+  const badgeClass = {
+    'AH': 'teal',
+    'EC': 'orange',
+    'MM': 'orange',
+    'NM': 'green',
+    'NS': 'green',
+    'SH': 'blue',
+    'WC': 'purple',
+    'WL': 'red'
+  };
+
   let html = '<ul class="rvt-list-plain">';
   courses.forEach(c => {
-    html += `<li>${c.subj} ${c.nbr}: ${c.desc}</li>`;
+    const codes = Array.isArray(c.gened) ? c.gened : [c.gened];
+    const code = codes[0];
+    const color = badgeClass[code] || 'info';
+    html += `<li class="rvt-border-bottom rvt-p-top-sm rvt-p-bottom-sm">` +
+            `<span class="rvt-badge rvt-badge--${color}">${code}</span>` +
+            `<span class="rvt-ts-16 rvt-m-left-sm rvt-text-bold">${c.subj} ${c.nbr}</span>` +
+            `<span class="rvt-m-left-md">${c.desc}</span>` +
+            `</li>`;
   });
   html += '</ul>';
   return html;


### PR DESCRIPTION
## Summary
- add grid layout so filter interface sits beside results
- show GenEd badge, course number, and title in results

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_685eff0cbb2c832681b1b4bda87821f7