### PR TITLE
Remove nested rvt-cols class

### DIFF
--- a/js/interface.js
+++ b/js/interface.js
@@ -40,7 +40,7 @@ function buildFilters(interests, departments, courses) {
   const approvalTerms = collectApprovalTerms(courses);
 
   let html = '';
-  html += '<div class="rvt-cols-4-md rvt-p-all-none">';
+  html += '<div class="rvt-p-all-none">';
   html += '<h3 class="rvt-ts-md rvt-bold rvt-m-bottom-sm">Filters</h3>';
   html += '<div class="rvt-accordion filter-accordion rvt-m-bottom-md" data-rvt-accordion="filter-accordion">';
 


### PR DESCRIPTION
## Summary
- drop inner `.rvt-cols` class from the filters markup so the grid classes only apply to the direct children of `.rvt-row`

## Testing
- `npm test` *(fails: ENOENT package.json)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_685f00c6dbbc83268367e3a91b1d98f2