### PR TITLE
Fix GenEd area filter toggle

### DIFF
--- a/js/interface.js
+++ b/js/interface.js
@@ -27,10 +27,37 @@ export async function initInterface(onFilterChange) {
     }
   }
 
-  container.querySelectorAll('.triggerFetch').forEach(el => {
+
+  // General change listeners for all triggers except the GenEd area checkboxes.
+  const nonAreaTriggers = Array.from(container.querySelectorAll('.triggerFetch'))
+    .filter(el => el.name !== 'area-checkboxes');
+  nonAreaTriggers.forEach(el => {
     el.addEventListener('change', handleChange);
     el.addEventListener('input', handleChange);
   });
+
+  // Special behavior for GenEd Area checkboxes
+  const allArea = container.querySelector('#area-checkbox-all');
+  const areaBoxes = Array.from(container.querySelectorAll('input[name="area-checkboxes"]'))
+    .filter(el => el !== allArea);
+
+  function handleAreaChange(e) {
+    if (e.target === allArea) {
+      if (allArea.checked) {
+        areaBoxes.forEach(cb => { cb.checked = false; });
+      }
+    } else {
+      if (e.target.checked) {
+        allArea.checked = false;
+      } else if (!areaBoxes.some(cb => cb.checked)) {
+        allArea.checked = true;
+      }
+    }
+    handleChange();
+  }
+
+  allArea.addEventListener('change', handleAreaChange);
+  areaBoxes.forEach(cb => cb.addEventListener('change', handleAreaChange));
 
   handleChange();
 }


### PR DESCRIPTION
## Summary
- prevent 'All GenEd Areas' from staying checked when other areas are selected
- automatically re-check 'All GenEd Areas' if no other areas remain checked

## Testing
- `node -e "import('./js/interface.js').then(()=>console.log('OK')).catch(e=>console.error(e))" --no-warnings`
- `node -e "import('./js/app.js').then(()=>console.log('OK')).catch(e=>console.error(e))" --no-warnings` *(fails: document is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_685f049df2f8832681df569df90d5d66