### PR TITLE
Avoid duplicate course fetch

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -5,9 +5,17 @@ let allCourses = [];
 let filteredCourses = [];
 let currentPage = 1;
 let pendingFilters = null;
+let coursesPromise = null;
+
+function getAllCourses() {
+  if (!coursesPromise) {
+    coursesPromise = fetch('gened-data/explore-gened.json').then(r => r.json());
+  }
+  return coursesPromise;
+}
 
 async function loadCourses() {
-  allCourses = await fetch('gened-data/explore-gened.json').then(r => r.json());
+  allCourses = await getAllCourses();
   if (pendingFilters) {
     applyFilters(pendingFilters);
     pendingFilters = null;
@@ -153,9 +161,10 @@ function setupAccordions(root) {
   });
 }
 
-document.addEventListener('DOMContentLoaded', () => {
-  initInterface(applyFilters);
-  loadCourses();
+document.addEventListener('DOMContentLoaded', async () => {
+  const courses = await getAllCourses();
+  initInterface(courses, applyFilters);
+  await loadCourses();
 
   document.querySelector('#course-list').addEventListener('click', (e) => {
     const btn = e.target.closest('.pagination-btn');
@@ -215,4 +224,4 @@ function filterCourseList() {
   applyFilters(filters);
 }
 
-export { filterCourseList };
+export { filterCourseList, getAllCourses };

--- a/js/interface.js
+++ b/js/interface.js
@@ -14,11 +14,10 @@ export function uniqueAccordionId(prefix = 'accordion') {
   return `${prefix}-${accordionCounter}`;
 }
 
-export async function initInterface(onFilterChange) {
-  const [interests, departments, courses] = await Promise.all([
+export async function initInterface(courses, onFilterChange) {
+  const [interests, departments] = await Promise.all([
     fetch('gened-data/explore-interests.json').then(r => r.json()),
-    fetch('gened-data/departments.json').then(r => r.json()),
-    fetch('gened-data/explore-gened.json').then(r => r.json())
+    fetch('gened-data/departments.json').then(r => r.json())
   ]);
 
   const container = document.querySelector('#interface');


### PR DESCRIPTION
## Summary
- centralize course fetch logic in `getAllCourses`
- allow `initInterface` to accept courses instead of fetching them
- load courses once in `app.js` and pass them to the interface initializer

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_685f097e7dfc83268bbe2c09cdd18ff1