### PR TITLE
Fix duplicate export of uniqueAccordionId

### DIFF
--- a/js/interface.js
+++ b/js/interface.js
@@ -250,4 +250,4 @@ function collectFilters(root) {
   };
 }
 
-export { collectFilters, uniqueAccordionId };
+export { collectFilters };


### PR DESCRIPTION
## Summary
- remove duplicate `uniqueAccordionId` export

## Testing
- `grep -n "uniqueAccordionId" js/interface.js`

------
https://chatgpt.com/codex/tasks/task_e_685f0ace85ec83269cbadc3f588ca67d