### PR TITLE
Fix duplicate variable declaration in interface.js

### DIFF
--- a/js/interface.js
+++ b/js/interface.js
@@ -15,19 +15,13 @@ export function uniqueAccordionId(prefix = 'accordion') {
 }
 
 export async function initInterface(courses, onFilterChange) {
-  const [interests, departments] = await Promise.all([
-    fetch('gened-data/explore-interests.json').then(r => r.json()),
-    fetch('gened-data/departments.json').then(r => r.json())
-  ]);
-
   const container = document.querySelector('#interface');
-  let interests, departments, courses;
+  let interests, departments;
   try {
     // Load interface data used for filters.
-    [interests, departments, courses] = await Promise.all([
+    [interests, departments] = await Promise.all([
       fetch('gened-data/explore-interests.json').then(r => r.json()),
-      fetch('gened-data/departments.json').then(r => r.json()),
-      fetch('gened-data/explore-gened.json').then(r => r.json())
+      fetch('gened-data/departments.json').then(r => r.json())
     ]);
   } catch (err) {
     // Show a placeholder alert when the filter data cannot be retrieved.


### PR DESCRIPTION
## Summary
- remove redundant data fetching in `initInterface`
- rely on the passed `courses` list when building filter UI

## Testing
- `node -c js/interface.js`
- `node -c js/app.js`

------
https://chatgpt.com/codex/tasks/task_e_685f0b3a5f6c83268906faf41d3c84ff