### PR TITLE
Add id and improve GenEd filter clarity

### DIFF
--- a/js/interface.js
+++ b/js/interface.js
@@ -144,7 +144,7 @@ function buildGenEdAreaList(meta) {
       </li>`).join('');
 
   return `
-    <fieldset class="rvt-fieldset">
+    <fieldset class="rvt-fieldset" id="gened-area-filter">
       <legend class="rvt-sr-only">GenEd Areas</legend>
       <ul class="rvt-list-plain rvt-width-xl">
         <li>


### PR DESCRIPTION
## Summary
- add `gened-area-filter` id to the GenEd area fieldset
- this helps target the fieldset for behavior that unchecks "All" when another area is chosen and checks it again if no specific area remains

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685f0ccef21c8326a849b74344d14e24