### PR TITLE
Fix dynamic accordion initialization

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -197,7 +197,11 @@ function render() {
   html += renderCourses(pageCourses);
   html += renderPagination();
   container.innerHTML = html;
-  setupAccordions(container);
+  if (window.Rivet && typeof window.Rivet.init === 'function') {
+    window.Rivet.init(container);
+  } else {
+    setupAccordions(container);
+  }
 }
 
 function setupAccordions(root) {


### PR DESCRIPTION
## Summary
- reinitialize Rivet accordions after re-rendering the course list

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_685f12ea2c548326bc0f9efcaf89ac0c