### PR TITLE
Fix repeated Rivet initialization

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -198,7 +198,8 @@ function render() {
   html += renderPagination();
   container.innerHTML = html;
   if (window.Rivet && typeof window.Rivet.init === 'function') {
-    window.Rivet.init(container);
+    // Rivet was initialized globally, so dynamically added accordions are
+    // automatically picked up by its MutationObserver.
   } else {
     setupAccordions(container);
   }

--- a/js/interface.js
+++ b/js/interface.js
@@ -38,9 +38,10 @@ export async function initInterface(courses, onFilterChange) {
   }
 
   container.innerHTML = buildFilters(interests, departments, courses);
-  if (window.Rivet && typeof window.Rivet.init === 'function') {
-    window.Rivet.init(container);
-  }
+
+  // Rivet's components are initialized globally once in index.html. The
+  // library automatically handles any DOM nodes added later via its
+  // MutationObserver so we no longer need to call `Rivet.init` here.
 
   function describeInteraction(target) {
     if (!target) return '';


### PR DESCRIPTION
## Summary
- rely on global Rivet.init call
- remove later redundant calls in interface.js and app.js

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_685f1579e4288326bed41f6a352b544e