### PR TITLE
Fix historical approval filtering

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -268,7 +268,10 @@ function applyFilters(filters) {
 
 
     if (filters.approvalTerm) {
-      if (String(c.firstApprovalYearCode) !== String(filters.approvalTerm)) return false;
+      const term = parseInt(filters.approvalTerm, 10);
+      const first = parseInt(c.firstApprovalYearCode, 10);
+      const last = c.lastApprovalYearCode ? parseInt(c.lastApprovalYearCode, 10) : NaN;
+      if (!(first <= term && (isNaN(last) || last >= term))) return false;
     }
 
     return true;


### PR DESCRIPTION
## Summary
- expand approvalTerm filter logic to include courses still active in the selected year

## Testing
- `node --check js/app.js`
- `node --check js/interface.js`


------
https://chatgpt.com/codex/tasks/task_e_685f16abd7788326ad0f201d6c47cfea