### PR TITLE
Fix interest category filtering

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -256,7 +256,8 @@ function applyFilters(filters) {
     }
 
     if (filters.interests && filters.interests.length) {
-      if (!c.interests || !filters.interests.some(i => c.interests.includes(i))) return false;
+      const cats = c.interestCategories || [];
+      if (!filters.interests.some(i => cats.includes(i))) return false;
     }
 
     if (filters.keyword) {


### PR DESCRIPTION
## Summary
- filter using `interestCategories` property so interest category checkboxes work properly

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_685f1a44179483268c092c74398e0b78