### PR TITLE
Update NM badge label and filter logic

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -278,7 +278,13 @@ function applyFilters(filters) {
     // areas
     if (filters.areas && filters.areas.length && !filters.areas.includes('all')) {
       const codes = Array.isArray(c.gened) ? c.gened : [c.gened];
-      if (!filters.areas.some(a => codes.includes(a))) return false;
+      const matchArea = filters.areas.some(a => {
+        if (a === 'NM|NS') {
+          return codes.includes('NM') || codes.includes('NS');
+        }
+        return codes.includes(a);
+      });
+      if (!matchArea) return false;
     }
 
     if (filters.departments && filters.departments.length) {

--- a/js/interface.js
+++ b/js/interface.js
@@ -162,18 +162,22 @@ function accordionSection(key, title, innerHtml, init = false) {
  * for every area defined in the metadata.
  */
 function buildGenEdAreaList(meta) {
-  const items = Object.entries(meta).map(([code, info]) => `
+  const items = Object.entries(meta).map(([code, info]) => {
+    const display = code === 'NM|NS' ? 'NM' : code;
+    const id = `area-checkbox-${display.toLowerCase()}`;
+    return `
       <li>
         <div class="rvt-checkbox">
           <input class="triggerFetch" type="checkbox" name="area-checkboxes"
-                 data-value="${code}" id="area-checkbox-${code.toLowerCase().replace('|','')}">
-          <label for="area-checkbox-${code.toLowerCase().replace('|','')}">
+                 data-value="${code}" id="${id}">
+          <label for="${id}">
             <span class="rvt-badge" style="font-size:14px; margin-right:5px; min-width:44px; text-align:center; border-color: ${info.color}; background: ${info.color}">
-              ${code.replace('|','')}
+              ${display}
             </span> ${info.label}
           </label>
         </div>
-      </li>`).join('');
+      </li>`;
+  }).join('');
 
   return `
     <fieldset class="rvt-fieldset" id="gened-area-filter">


### PR DESCRIPTION
## Summary
- show `NM` as the badge text for Natural & Mathematical Sciences
- match both `NM` and `NS` gened areas when the `NM` filter is selected

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_685f1c1813f0832688866e199eb0a255