### PR TITLE
Fix disabled state for 'All GenEd Areas' checkbox

### DIFF
--- a/js/interface.js
+++ b/js/interface.js
@@ -90,16 +90,28 @@ export async function initInterface(courses, onFilterChange) {
   const areaBoxes = Array.from(container.querySelectorAll('input[name="area-checkboxes"]'))
     .filter(el => el !== allArea);
 
+  // When "All GenEd Areas" is checked, it should be disabled so users
+  // cannot uncheck it directly. The checkbox becomes enabled again when any
+  // specific area option is selected.
+  if (allArea) {
+    allArea.disabled = allArea.checked;
+  }
+
   function handleAreaChange(e) {
     if (e.target === allArea) {
       if (allArea.checked) {
         areaBoxes.forEach(cb => { cb.checked = false; });
+        allArea.disabled = true;
+      } else {
+        allArea.disabled = false;
       }
     } else {
       if (e.target.checked) {
         allArea.checked = false;
+        allArea.disabled = false;
       } else if (!areaBoxes.some(cb => cb.checked)) {
         allArea.checked = true;
+        allArea.disabled = true;
       }
     }
     handleChange(e);


### PR DESCRIPTION
## Summary
- disable the 'All GenEd Areas' checkbox whenever it is checked
- enable it again when a specific area option is chosen

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open '/workspace/gened/package.json')*

------
https://chatgpt.com/codex/tasks/task_e_685f1cbd15848326b4f6b8416353e27f