### PR TITLE
Add padding class to accordion buttons

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -85,7 +85,7 @@ function renderCourses(courses) {
     `.trim();
     html += `
       <h4 class="rvt-accordion__summary rvt-border-bottom">
-        <button class="rvt-accordion__toggle" id="${id}-label" data-rvt-accordion-trigger="${id}" aria-expanded="false">
+        <button class="rvt-accordion__toggle rvt-p-all-xs" id="${id}-label" data-rvt-accordion-trigger="${id}" aria-expanded="false">
           <span class="rvt-accordion__toggle-text">
             ${summary}
           </span>

--- a/js/interface.js
+++ b/js/interface.js
@@ -141,7 +141,7 @@ function accordionSection(key, title, innerHtml, init = false) {
   const id = `filter-${key}`;
   const initAttr = init ? ' data-rvt-accordion-panel-init="true"' : '';
   return `<h4 class="rvt-accordion__summary">
-    <button class="rvt-accordion__toggle" id="${id}-label" data-rvt-accordion-trigger="${id}" aria-expanded="false">
+    <button class="rvt-accordion__toggle rvt-p-all-xs" id="${id}-label" data-rvt-accordion-trigger="${id}" aria-expanded="false">
       <span class="rvt-accordion__toggle-text${key==='areas'? ' rvt-ts-sm':''}">${title}</span>
       <div class="rvt-accordion__toggle-icon">
         <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">


### PR DESCRIPTION
## Summary
- apply Rivet `.rvt-p-all-xs` utility to accordion toggle buttons so they get consistent padding

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685f1d198dcc8326928605ed44865e97