### PR TITLE
Enhance course result label with range info

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -223,7 +223,13 @@ function render() {
   captureFocus();
   const start = (currentPage - 1) * pageSize;
   const pageCourses = filteredCourses.slice(start, start + pageSize);
-  let html = `<h3>${filteredCourses.length} course results</h3>`;
+  const showingStart = filteredCourses.length ? start + 1 : 0;
+  const showingEnd = Math.min(start + pageSize, filteredCourses.length);
+  let html = `<h3>${filteredCourses.length} Courses`;
+  if (filteredCourses.length) {
+    html += ` (Showing Courses ${showingStart}-${showingEnd})`;
+  }
+  html += `</h3>`;
   html += renderCourses(pageCourses);
   html += renderPagination();
   container.innerHTML = html;


### PR DESCRIPTION
## Summary
- include start and end numbers of currently displayed courses in the course list label

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_685f1decb4608326a98d0650d34a7378