### PR TITLE
Fix course result wrap

### DIFF
--- a/app.css
+++ b/app.css
@@ -9,3 +9,10 @@ nav[aria-label="Pagination"] {
 nav[aria-label="Pagination"] .rvt-pagination {
     justify-content: center;
 }
+
+/* Display the badge, course code, and description side by side */
+#course-list .rvt-accordion__toggle-text {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: baseline;
+}


### PR DESCRIPTION
## Summary
- ensure results' summary spans sit on the same line using flexbox

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685f1d97497c8326b6c14b5b005730a7