### PR TITLE
Update summary layout for courses

### DIFF
--- a/app.css
+++ b/app.css
@@ -10,9 +10,9 @@ nav[aria-label="Pagination"] .rvt-pagination {
     justify-content: center;
 }
 
-/* Display the badge, course code, and description side by side */
+/* Display the course summary pieces in fixed and flexible columns */
 #course-list .rvt-accordion__toggle-text {
-    display: flex;
-    flex-wrap: wrap;
+    display: grid;
+    grid-template-columns: 50px 100px 1fr;
     align-items: baseline;
 }


### PR DESCRIPTION
## Summary
- switch `.rvt-accordion__toggle-text` for course summaries to `grid`
- define grid columns so badge, code, and description have sizes `50px`, `100px`, and `1fr`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685f200d2e4c8326b56d95899b6ba228