### PR TITLE
Adjust fallback badge color for readability

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -76,7 +76,7 @@ function renderCourses(courses) {
   courses.forEach(c => {
     const codes = Array.isArray(c.gened) ? c.gened : [c.gened];
     const code = codes[0];
-    const color = areaColors[code] || '#888';
+    const color = areaColors[code] || '#666';
     const id = `course-${c.id}`;
     const summary = `
       <span class="rvt-badge" style="background:${color}; border-color:${color}">${code}</span>


### PR DESCRIPTION
## Summary
- update course badge fallback color from `#888` to `#666`

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_685f213940a08326aca3e03105144bd0