### PR TITLE
Fix badge width in course list

### DIFF
--- a/app.css
+++ b/app.css
@@ -16,3 +16,8 @@ nav[aria-label="Pagination"] .rvt-pagination {
     grid-template-columns: 50px 140px 1fr;
     align-items: baseline;
 }
+
+#course-list .badge-cell {
+    display: flex;
+    align-items: center;
+}

--- a/js/app.js
+++ b/js/app.js
@@ -80,7 +80,9 @@ function renderCourses(courses) {
     const color = areaColors[code] || '#666';
     const id = `course-${c.id}`;
     const summary = `
-      <span class="rvt-badge" style="background:${color}; border-color:${color}">${code}</span>
+      <span class="badge-cell">
+        <span class="rvt-badge" style="background:${color}; border-color:${color}">${code}</span>
+      </span>
       <span class="rvt-ts-16 rvt-m-left-sm rvt-text-bold">${c.subj} ${c.nbr}</span>
       <span class="rvt-m-left-md">${c.desc}</span>
     `.trim();


### PR DESCRIPTION
## Summary
- avoid stretching badges inside the course list by wrapping them in a new `.badge-cell`
- add styles for `.badge-cell` to keep badges sized to content

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_685f23cfc7c883269907a7ca150b3a5f