### PR TITLE
Remove left margin on course description spans

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -83,7 +83,7 @@ function renderCourses(courses) {
         <span class="rvt-badge" style="background:${color}; border-color:${color}">${code}</span>
       </span>
       <span class="rvt-ts-16 rvt-m-left-sm rvt-text-bold">${c.subj} ${c.nbr}</span>
-      <span class="rvt-m-left-md">${c.desc}</span>
+      <span>${c.desc}</span>
     `.trim();
     html += `
       <h4 class="rvt-accordion__summary rvt-border-bottom">


### PR DESCRIPTION
## Summary
- update the course list HTML so description spans no longer include the `rvt-m-left-md` class

## Testing
- `npm test` *(fails: package.json missing)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_685f267be2288326b4da500a1714886f