### PR TITLE
Fix course accordion padding

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -87,7 +87,7 @@ function renderCourses(courses) {
     `.trim();
     html += `
       <h4 class="rvt-accordion__summary rvt-border-bottom">
-        <button class="rvt-accordion__toggle rvt-p-all-md" id="${id}-label" data-rvt-accordion-trigger="${id}" aria-expanded="false">
+        <button class="rvt-accordion__toggle rvt-p-all-sm" id="${id}-label" data-rvt-accordion-trigger="${id}" aria-expanded="false">
           <span class="rvt-accordion__toggle-text">
             ${summary}
           </span>


### PR DESCRIPTION
## Summary
- reduce padding for course results buttons from medium to small

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_685f274eb4048326bc9a8e68852e9f46